### PR TITLE
Destroy pending client connection on timeout

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ module.exports = function waitTillListening(options, callback) {
     'options.timeoutInMs must be a positive number');
 
   var finished = false;
+  var client;
 
   setTimeout(failWithTimeout, options.timeoutInMs);
   tryConnect();
@@ -26,7 +27,7 @@ module.exports = function waitTillListening(options, callback) {
     if (finished) return;
     debug('Trying to connect to %s:%s', options.host, options.port);
 
-    var client = net.connect({
+    client = net.connect({
       host: options.host,
       port: options.port
     });
@@ -56,6 +57,9 @@ module.exports = function waitTillListening(options, callback) {
   function failWithTimeout() {
     if (finished) return;
     finished = true;
+
+    // Destroy any pending connection. We no longer care about the result.
+    if (client) client.destroy();
 
     var msg = 'Timed out while waiting for a server listening on ' +
       options.host + ':' + options.port;


### PR DESCRIPTION
A followup for comment in #1:

> I would destroy connection after timeout. Otherwise, the connection keeps on going, trying to be made, even though you timed out. But if this is all localhost, probably doesn't matter.

/to @sam-github please review. Is this what you had in mind?
/cc @ritch 
