### PR TITLE
Clear timeouts when callback is called

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,10 +17,12 @@
     "email": "miroslav@strongloop.com"
   },
   "devDependencies": {
-    "chai": "^1.9.2",
+    "chai": "^3.4.1",
     "debug": "^2.0.0",
     "jshint": "^2.5.6",
-    "mocha": "^1.21.4"
+    "mocha": "^1.21.4",
+    "sinon": "^1.17.2",
+    "sinon-chai": "^2.8.0"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
Our build tasks were hanging unnecessarily long, and we discovered it was because strong-wait-till-listening was not clearing its timeouts. Clearing timeouts allows you to wait for arbitrarily large times (which is occasionally necessary such as on containers with weak CPUs) without causing the same tasks run locally to hang after swift completion.